### PR TITLE
Update 20200125

### DIFF
--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -163,6 +163,7 @@
         "type": "forecast",
         "cache": 6,
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
+	"bathymetry_file_url": "/data/grids/ecc/misc/polar_stereographic/bathy_meter_giops_ps5km.nc",
         "url": "/data/db/riops-fc3dps.sqlite3",
         "grid_angle_file_url": "/data/grids/ecc/riops/grid_angle_riops_ps5km60n.nc",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
@@ -184,7 +185,8 @@
 	    "oxygensaturation": { "hide": "true", "name": "Oxygen Saturation", "scale": [4, 11], "unit": "ml/l", "equation": "oxygensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
 	    "nitrogensaturation": { "hide": "true", "name": "Nitrogen Saturation", "scale": [8, 20], "unit": "ml/l", "equation": "nitrogensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [1.5, 60], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
-            "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
+            "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
+	    "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] }
         }
     },
     "riops_fc_2dps": {

--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -28,43 +28,10 @@
 	    "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] }
         }
     },
-    "giops_fc_10day_3dps": {
-        "envtype": ["ocean", "ice"],
-        "url": "/data/db/giops-fc3dps-10day.sqlite3",
-        "grid_angle_file_url": "/data/grids/ecc/giops/grid_angle_giops_ps5km60n.nc",
-        "name": "02. GIOPS 10 day Forecast 3D - Polar Stereographic",
-        "quantum": "day",
-        "type": "forecast",
-        "time_dim_units": "seconds since 1950-01-01 00:00:00",
-        "enabled": true,
-        "cache": 6,
-        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
-        "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
-        "lat_var_key": "latitude",
-        "lon_var_key": "longitude",
-        "help": " Document <a href=\"../data-help/giops-10day.html\" target=\"_new\">link</a>.",
-
-        "variables": {
-            "vozocrtx": { "hide": "true", "name": "Water X Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "vomecrty": { "hide": "true","name": "Water Y Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "vomecrtn": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "equation": "vozocrtx * sin_alpha + vomecrty * cos_alpha", "zero_centered": "true" , "dims": ["time", "depth", "yc", "xc"] },
-            "vozocrte": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "equation": "vozocrtx * cos_alpha - vomecrty * sin_alpha", "zero_centered": "true", "dims": ["time", "depth", "yc", "xc"] },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "yc", "xc"], "east_vector_component": "vozocrte", "north_vector_component": "vomecrtn" },
-            "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "yc", "xc"] },
-            "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
-            "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "density": { "hide": "true", "name": "Water Density", "envtype": "ocean", "scale": [1000, 1030], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "heatcapacity": { "hide": "true", "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "tempgradient": { "hide": "true", "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "deepsoundchannel": { "name": "Sound Channel Axis", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
-            "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [1.5, 60], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
-            "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
-        }
-    },
     "giops_fc_10d_2dll": {
         "envtype": ["ocean", "ice"],
         "url": "/data/db/giops-fc2dll-10day.sqlite3",
-        "name": "03. GIOPS 10 day Forecast Surface - LatLon",
+        "name": "02. GIOPS 10 day Forecast Surface - LatLon",
         "quantum": "day",
         "type": "forecast",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
@@ -96,50 +63,10 @@
             "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] }
         }
     },
-    "giops_fc_10day_2dps": {
-        "envtype": ["ocean", "ice"],
-        "url": "/data/db/giops-fc2dps-10day.sqlite3",
-        "grid_angle_file_url": "/data/grids/ecc/giops/grid_angle_giops_ps5km60n.nc",
-        "name": "04. GIOPS 10 day Forecast Surface - Polar Stereographic",
-        "quantum": "hour",
-        "type": "forecast",
-        "time_dim_units": "seconds since 1950-01-01 00:00:00",
-        "enabled": true,
-        "cache": 6,
-        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
-        "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
-        "lat_var_key": "latitude",
-        "lon_var_key": "longitude",
-        "help": " Document <a href=\"../data-help/giops-10day.html\" target=\"_new\">link</a>.",
-
-        "variables": {
-            "vozocrtx": { "hide": "true", "name": "Water X Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "vomecrty": { "hide": "true", "name": "Water Y Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "vozocrte": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "equation": "vozocrtx * cos_alpha - vomecrty * sin_alpha", "zero_centered": "true", "dims": ["time", "yc", "xc"] },
-            "vomecrtn": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "equation": "vozocrtx * sin_alpha + vomecrty * cos_alpha", "zero_centered": "true" , "dims": ["time", "yc", "xc"] },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vomecrty, vozocrtx)",  "dims": ["time", "yc", "xc"], "east_vector_component": "vozocrte", "north_vector_component": "vomecrtn" },
-            "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "yc", "xc"] },
-            "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
-            "sossheig": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-3, 3], "zero_centered": "true" },
-            "iiceconc": { "name": "Ice Concentration", "envtype": "ice", "unit": "fraction", "scale": [0, 1] },
-            "iicevol": { "name": "Ice Volume", "envtype": "ice", "unit": "m", "scale": [0, 10] },
-            "somixhgt": { "name": "Turbocline Depth", "envtype": "ocean", "unit": "m", "scale": [0, 4000] },
-            "sokaraml": { "name": "Ocean Mixed Layer Depth", "envtype": "ocean", "unit": "m", "scale": [0, 4000] },
-            "iicesurftemp": { "name": "Surface Temp Over Sea Ice", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "iicesurftemp - 273.15", "dims": ["time", "yc", "xc"] },
-            "isnowvol": { "name": "Snow Volume", "envtype": "ice", "unit": "cm", "scale": [0, 2000] },
-            "itmecrty": { "hide": "true", "name": "Sea Ice Y Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
-            "itzocrtx": { "hide": "true", "name": "Sea Ice X Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
-            "itzocrte": { "name": "Sea Ice East Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "equation": "itzocrtx * cos_alpha - itmecrty * sin_alpha", "zero_centered": "true", "dims": ["time", "yc", "xc"] },
-            "itmecrtn": { "name": "Sea Ice North Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "equation": "itzocrtx * sin_alpha + itmecrty * cos_alpha", "zero_centered": "true", "dims": ["time", "yc", "xc"] },
-            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itzocrtx, itmecrty)", "dims": ["time", "yc", "xc"], "east_vector_component": "itzocrte", "north_vector_component": "itmecrtn" },
-            "iicestrength": { "name": "Compressive Ice Strength", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] },
-            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] }
-        }
-    },
     "giops_fc_2dll": {
         "envtype": ["ocean", "ice"],
         "url": "/data/db/giops-fc2dll.sqlite3",
-        "name": "05. GIOPS 3 hr mean Forecast Surface - LatLon",
+        "name": "03. GIOPS 3 hr mean Forecast Surface - LatLon",
         "quantum": "hour",
         "type": "forecast",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
@@ -171,50 +98,11 @@
             "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] }
          }
     },
-    "giops_fc_2dps": {
-        "envtype": ["ocean", "ice"],
-        "url": "/data/db/giops-fc2dps.sqlite3",
-        "grid_angle_file_url": "/data/grids/ecc/giops/grid_angle_giops_ps5km60n.nc",
-        "name": "06. GIOPS 3 hr mean Forecast Surface - Polar Stereographic",
-        "quantum": "hour",
-        "type": "forecast",
-        "time_dim_units": "seconds since 1950-01-01 00:00:00",
-        "enabled": true,
-        "cache": 6,
-        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
-        "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
-        "lat_var_key": "latitude",
-        "lon_var_key": "longitude",
-        "help": " Document <a href=\"../data-help/giops-surface.html\" target=\"_new\">link</a>.",
-
-        "variables": {
-            "vozocrtx": { "hide": "true", "name": "Water X Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "vomecrty": { "hide": "true", "name": "Water Y Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "vozocrte": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "equation": "vozocrtx * cos_alpha - vomecrty * sin_alpha", "zero_centered": "true", "dims": ["time", "yc", "xc"] },
-            "vomecrtn": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [ -3, 3 ], "equation": "vozocrtx * sin_alpha + vomecrty * cos_alpha", "zero_centered": "true" , "dims": ["time", "yc", "xc"] },
-            "magwatervel": {"name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)", "dims": ["time", "yc", "xc"], "east_vector_component": "vozocrte", "north_vector_component": "vomecrtn" },
-            "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "yc", "xc"] },
-            "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
-            "sossheig": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-3, 3], "zero_centered": "true" },
-            "iiceconc": { "name": "Ice Concentration", "envtype": "ice", "unit": "fraction", "scale": [0, 1] },
-            "iicevol": { "name": "Ice Volume", "envtype": "ice", "unit": "m", "scale": [0, 10] },
-            "somixhgt": { "name": "Turbocline Depth", "envtype": "ocean", "unit": "m", "scale": [0, 4000] },
-            "sokaraml": { "name": "Ocean Mixed Layer Depth", "envtype": "ocean", "unit": "m", "scale": [0, 4000] },
-            "iicesurftemp": { "name": "Surface Temp Over Sea Ice", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "iicesurftemp - 273.15", "dims": ["time", "yc", "xc"] },
-            "isnowvol": { "name": "Snow Volume", "envtype": "ice", "unit": "cm", "scale": [0, 2000] },
-            "itmecrty": { "hide": "true","name": "Sea Ice Y Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
-            "itzocrtx": { "hide": "true","name": "Sea Ice X Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
-            "itzocrte": { "name": "Sea Ice East Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "equation": "itzocrtx * cos_alpha - itmecrty * sin_alpha", "zero_centered": "true", "dims": ["time", "yc", "xc"] },
-            "itmecrtn": { "name": "Sea Ice North Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "equation": "itzocrtx * sin_alpha + itmecrty * cos_alpha", "zero_centered": "true", "dims": ["time", "yc", "xc"] },
-            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itzocrtx, itmecrty)", "dims": ["time", "yc", "xc"], "east_vector_component": "itzocrte", "north_vector_component": "itmecrtn" },
-            "iicestrength": { "name": "Compressive Ice Strength", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] },
-            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] }
-        }
-    },
     "giops_fc_3dll": {
         "envtype": ["ocean", "ice"],
         "url": "/data/db/giops-fc3dll.sqlite3",
-        "name": "07. GIOPS Daily Forecast 3D - LatLon",
+	"bathymetry_file_url": "/data/grids/ecc/misc/lat_lon/bathy_meter_giops_latlon_0.2deg_reformatted_lonlatupdate.nc",
+        "name": "04. GIOPS Daily Forecast 3D - LatLon",
         "quantum": "day",
         "type": "forecast",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
@@ -238,45 +126,12 @@
             "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] }
         }
     },
-    "giops_fc_3dps": {
-        "envtype": ["ocean", "ice"],
-        "url": "/data/db/giops-fc3dps.sqlite3",
-        "grid_angle_file_url": "/data/grids/ecc/giops/grid_angle_giops_ps5km60n.nc",
-        "name": "08. GIOPS Daily Forecast 3D - Polar Stereographic",
-        "quantum": "day",
-        "type": "forecast",
-        "time_dim_units": "seconds since 1950-01-01 00:00:00",
-        "enabled": false,
-        "cache": 6,
-        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
-        "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
-        "lat_var_key": "latitude",
-        "lon_var_key": "longitude",
-        "help": " Document <a href=\"../data-help/giops-3d.html\" target=\"_new\">link</a>.",
-
-        "variables": {
-            "vozocrtx": { "hide": "true", "name": "Water X Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "vomecrty": { "hide": "true", "name": "Water Y Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "vozocrte": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "equation": "vozocrtx * cos_alpha - vomecrty * sin_alpha" , "zero_centered": "true", "dims": ["time", "depth", "yc", "xc"] },
-            "vomecrtn": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "equation": "vozocrtx * sin_alpha + vomecrty * cos_alpha", "zero_centered": "true" , "dims": ["time", "depth", "yc", "xc"] },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "yc", "xc"], "east_vector_component": "vozocrte", "north_vector_component": "vomecrtn" },
-            "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "yc", "xc"] },
-            "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
-            "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "density": { "hide": "true", "name": "Water Density", "envtype": "ocean", "scale": [1000, 1030], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "heatcapacity": { "hide": "true", "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "tempgradient": { "hide": "true", "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "deepsoundchannel": { "name": "Sound Channel Axis", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
-            "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [1.5, 60], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
-            "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
-        }
-    },
     "riops_fc_2dll": {
         "climatology": "",
         "envtype": ["ocean", "ice"],
         "enabled": true,
         "help": " Document <a href=\"../data-help/riops-surface.html\" target=\"_new\">link</a>.",
-	"name": "08. CCG RIOPS Forecast Surface - LatLon",
+	"name": "05. CCG RIOPS Forecast Surface - LatLon",
         "quantum": "hour",
         "type": "forecast",
         "cache": 6,
@@ -302,12 +157,13 @@
         "envtype": ["ocean"],
         "enabled": true,
         "help": " Document <a href=\"../data-help/riops-3d.html\" target=\"_new\">link</a>.",
-        "name": "09. RIOPS Forecast 3D - Polar Stereographic",
+        "name": "06. RIOPS Forecast 3D - Polar Stereographic",
         "quantum": "hour",
         "type": "forecast",
         "cache": 6,
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "url": "/data/db/riops-fc3dps.sqlite3",
+	"bathymetry_file_url": "/data/grids/ecc/misc/lat_lon/bathy_meter_giops_latlon_0.2deg_reformatted_lonlatupdate.nc",
         "grid_angle_file_url": "/data/grids/ecc/riops/grid_angle_riops_ps5km60n.nc",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
         "lat_var_key": "latitude",
@@ -336,7 +192,7 @@
         "envtype": ["ocean"],
         "enabled": true,
         "help": " Document <a href=\"../data-help/riops-surface.html\" target=\"_new\">link</a>.",
-        "name": "10. RIOPS Forecast Surface - Polar Stereographic",
+        "name": "07. RIOPS Forecast Surface - Polar Stereographic",
         "quantum": "hour",
         "type": "forecast",
         "cache": 6,
@@ -373,7 +229,7 @@
     "wcps_2dll": {
         "envtype": ["ocean", "ice"],
         "url": "/data/db/wcps-2dll.sqlite3",
-        "name": "11. WCPS-GLS Great Lakes Coupled Atmosphere-Ocean-Ice Forecast - LatLon",
+        "name": "08. WCPS-GLS Great Lakes Coupled Atmosphere-Ocean-Ice Forecast - LatLon",
         "quantum": "hour",
         "type": "forecast",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
@@ -408,7 +264,7 @@
     "ciops_east3d": {
         "envtype": ["ocean", "ice"],
         "url": "/data/db/ciops_east-pseudo_anal-3d.sqlite3",
-        "name": "12. CIOPS East 3D Pseudo-analysis",
+        "name": "09. CIOPS East 3D Pseudo-analysis",
         "quantum": "hour",
         "type": "forecast",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
@@ -430,7 +286,7 @@
     "ciops_east": {
         "envtype": ["ocean", "ice"],
         "url": "/data/db/ciops_east-pseudo_anal.sqlite3",
-        "name": "13. CIOPS East Surface Pseudo-analysis",
+        "name": "10. CIOPS East Surface Pseudo-analysis",
         "quantum": "hour",
         "type": "forecast",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
@@ -452,7 +308,7 @@
     "ciops_west3d": {
         "envtype": ["ocean", "ice"],
         "url": "/data/db/ciops_west-pseudo_anal-3d.sqlite3",
-        "name": "14. CIOPS West 3D Pseudo-analysis",
+        "name": "11. CIOPS West 3D Pseudo-analysis",
         "quantum": "hour",
         "type": "forecast",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
@@ -474,7 +330,7 @@
     "ciops_west": {
         "envtype": ["ocean", "ice"],
         "url": "/data/db/ciops_west-pseudo_anal.sqlite3",
-        "name": "15. CIOPS West Surface Pseudo-analysis",
+        "name": "12. CIOPS West Surface Pseudo-analysis",
         "quantum": "hour",
         "type": "forecast",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
@@ -497,7 +353,7 @@
         "envtype": ["ocean", "ice"],
         "url": "/data/db/gsl-3d.sqlite3",
         "grid_angle_file_url": "/data/grids/gulf/grid_angle.nc",
-        "name": "16. Gulf of St. Lawrence 3D",
+        "name": "13. Gulf of St. Lawrence 3D",
         "quantum": "hour",
         "type": "forecast",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
@@ -523,7 +379,7 @@
         "envtype": ["ocean", "ice"],
         "url": "/data/db/gsl-surface-combined.sqlite3",
         "grid_angle_file_url": "/data/grids/gulf/grid_angle.nc",
-        "name": "17. Gulf of St. Lawrence Surface",
+        "name": "14. Gulf of St. Lawrence Surface",
         "quantum": "hour",
         "type": "forecast",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
@@ -547,7 +403,7 @@
     },
     "cmems-global-analysis-forecast-phy-001-024_hourly": {
         "url": "/data/db/global-analysis-forecast-phy-001-024-hourly-t-u-v-ssh.sqlite3",
-        "name": "18. CMEMS Global Ocean PHYS Analysis (Hourly) 1/12 deg",
+        "name": "15. CMEMS Global Ocean PHYS Analysis (Hourly) 1/12 deg",
         "quantum": "hour",
         "type": "historical",
         "time_dim_units": "hours since 1950-01-01",
@@ -568,7 +424,7 @@
     },
     "cmems-global-analysis-forecast-phy-001-024_monthly": {
         "url": "/data/db/global-analysis-forecast-phy-001-024-monthly.sqlite3",
-        "name": "19. CMEMS Global Ocean PHYS Analysis (Monthly) 1/12 deg",
+        "name": "16. CMEMS Global Ocean PHYS Analysis (Monthly) 1/12 deg",
         "quantum": "month",
         "type": "historical",
         "time_dim_units": "hours since 1950-01-01",
@@ -596,7 +452,7 @@
     },
     "cmems_daily": {
         "url": "/data/db/cmems_daily.sqlite3",
-        "name": "20. CMEMS Global Ocean PHYS Reanalysis (Daily) 1/12 deg",
+        "name": "17. CMEMS Global Ocean PHYS Reanalysis (Daily) 1/12 deg",
         "quantum": "day",
         "type": "historical",
         "time_dim_units": "hours since 1950-01-01",
@@ -624,7 +480,7 @@
     },
     "cmems_monthly": {
         "url": "/data/db/cmems_monthly.sqlite3",
-        "name": "21. CMEMS Global Ocean PHYS Reanalysis (Monthly) 1/12 deg",
+        "name": "18. CMEMS Global Ocean PHYS Reanalysis (Monthly) 1/12 deg",
         "quantum": "month",
         "type": "historical",
         "time_dim_units": "hours since 1950-01-01",
@@ -651,7 +507,7 @@
         }
     },
     "cmems_monthly_climatology": {
-        "name": "22. CMEMS Global Ocean PHYS Reanalysis Climatology (Monthly mean) 1/12 deg",
+        "name": "19. CMEMS Global Ocean PHYS Reanalysis Climatology (Monthly mean) 1/12 deg",
 	"url": "/data/db/mercatorglorys12v1_gl12_mean_monthly.sqlite3",
         "help": " Document <a href=\"../data-help/glorys12_climatology_monthly.html\" target=\"_new\">link</a>.",
 	"quantum": "month",
@@ -679,7 +535,7 @@
         }
     },
     "cmems_seasonal_climatolog": {
-        "name": "23. CMEMS Global Ocean PHYS Reanalysis Climatology (Seasonal mean) 1/12deg",
+        "name": "20. CMEMS Global Ocean PHYS Reanalysis Climatology (Seasonal mean) 1/12deg",
 	"url": "/data/db/mercatorglorys12v1_gl12_mean-seasonal.sqlite3",
 	"quantum": "month",
         "type": "historical",
@@ -706,60 +562,8 @@
             "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 430] }
         }
     },
-    "cmems_ran-arc-day": {
-        "url": "/data/db/cmems-artic_reanalysis_phys_002_003-dataset-ran-arc-day-myoceanv2-be.sqlite3",
-        "name": "Pilot Copernicus/TOPAZ Arctic reanalysis (daily)",
-        "quantum": "day",
-        "type": "historical",
-        "time_dim_units": "hours since 1950-01-01",
-        "enabled": false,
-        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
-        "attribution": "NERSC, Thormoehlens gate 47, N-5006 Bergen, Norway",
-        "lat_var_key": "latitude",
-        "lon_var_key": "longitude",
-        "help": "",
-        "variables": {
-            "temperature": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] },
-            "salinity": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
-            "v": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "u": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(u, v)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "u", "north_vector_component": "v" },
-            "vice": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "uice": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
-            "hice": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 10] },
-            "ssh": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] },
-            "mlp": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] }
-        }
-    },
-    "cmems_ran-arc": {
-        "url": "/data/db/cmems-artic_reanalysis_phys_002_003-dataset-ran-arc-myoceanv2-be.sqlite3",
-        "name": "Pilot Copernicus/TOPAZ Arctic reanalysis (Monthly)",
-        "quantum": "month",
-        "type": "historical",
-        "time_dim_units": "hours since 1950-01-01",
-        "enabled": false,
-        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
-        "attribution": "NERSC, Thormoehlens gate 47, N-5006 Bergen, Norway",
-        "lat_var_key": "latitude",
-        "lon_var_key": "longitude",
-        "help": "",
-        "variables": {
-            "temperature": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] },
-            "salinity": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
-            "v": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "u": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(u, v)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "u", "north_vector_component": "v" },
-            "vice": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "uice": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
-            "hice": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 10] },
-            "ssh": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] },
-            "mlp": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] }
-        }
-    },
     "freebiorys2v4_daily": {
-        "name": "24. CMEMS Global Ocean Reanalysis Bio (Daily)",
+        "name": "21. CMEMS Global Ocean Reanalysis Bio (Daily)",
         "quantum": "day",
         "type": "historical",
         "time_dim_units": "hours since 1950-01-01",
@@ -784,7 +588,7 @@
         }
      },
     "freebiorys2v4_monthly": {
-        "name": "25. CMEMS Global Ocean Reanalysis Bio (Monthly)",
+        "name": "22. CMEMS Global Ocean Reanalysis Bio (Monthly)",
         "quantum": "month",
         "type": "historical",
         "time_dim_units": "hours since 1950-01-01",
@@ -808,51 +612,9 @@
             "chl": { "name": "Total Chlorophyll", "unit": "mg/m^3", "scale": [0.03, 4.7] }
         }
     },
-    "arc-rean-bio_daily": {
-        "name": "MyOcean Arctic bio pilot reanalysis TOPAZ4(2007-2010) Daily",
-        "quantum": "day",
-        "type": "historical",
-        "time_dim_units": "hours since 1950-01-01",
-        "url": "/data/db/cmems-artic_reanalysis_bio_002_005-dataset-ran-day-arc-myoceanv2-be.sqlite3",
-        "enabled": false,
-        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
-        "attribution": "NERSC, Thormoehlens gate 47, N-5006 Bergen, Norway",
-        "lat_var_key": "latitude",
-        "lon_var_key": "longitude",
-        "help": "http://marine.copernicus.eu/services-portfolio/service-commitments-and-licence/",
-        "variables": {
-            "chla": { "name": "Chlorophyll Concentration", "unit": "mg/m^3", "scale": [0.03e-7, 4.5e-7] },
-            "nitrat": { "name": "Nitrate Concentration", "unit": "mmol/m^3", "scale": [0, 0.012] },
-            "phosphat": { "name": "Phosphate Concentration", "unit": "mmol/m^3", "scale": [0, 1.2e-3] },
-            "oxygen": { "name": "Oxygen Concentration", "unit": "mmol/m^3", "scale": [0, 0.013] },
-            "pbiomass": { "name": "Pytoplanton Concentration", "unit": "mmol/m^3", "scale": [0, 2e-4] },
-            "zbiomass": { "name": "Zooplankton Concentration", "unit": "mmol/m^3", "scale": [0, 1.1e-3] }
-        }
-     },
-    "arc-rean-bio_monthly": {
-        "name": "MyOcean Arctic bio pilot reanalysis TOPAZ4 (2007-2010) Monthly",
-        "quantum": "month",
-        "type": "historical",
-        "time_dim_units": "hours since 1950-01-01",
-        "url": "/data/db/cmems-artic_reanalysis_bio_002_005-dataset-ran-arc-myoceanv2-be.sqlite3",
-        "enabled": false,
-        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
-        "attribution": "NERSC, Thormoehlens gate 47, N-5006 Bergen, Norway",
-        "lat_var_key": "latitude",
-        "lon_var_key": "longitude",
-        "help": "http://marine.copernicus.eu/services-portfolio/service-commitments-and-licence/",
-        "variables": {
-            "chla": { "name": "Chlorophyll Concentration", "unit": "mg/m^3", "scale": [0.03e-7, 4.5e-7] },
-            "nitrat": { "name": "Nitrate Concentration", "unit": "mmol/m^3", "scale": [0, 0.012] },
-            "phosphat": { "name": "Phosphate Concentration", "unit": "mmol/m^3", "scale": [0, 1.2e-3] },
-            "oxygen": { "name": "Oxygen Concentration", "unit": "mmol/m^3", "scale": [0, 0.013] },
-            "pbiomass": { "name": "Pytoplanton Concentration", "unit": "mmol/m^3", "scale": [0, 2e-4] },
-            "zbiomass": { "name": "Zooplankton Concentration", "unit": "mmol/m^3", "scale": [0, 1.1e-3] }
-        }
-     },
     "salishseacast_3d_biology": {
         "enabled": true,
-        "name": "26. SalishSeaCast 3D Biology",
+        "name": "23. SalishSeaCast 3D Biology",
         "envtype": ["ocean"],
         "type": "historical",
         "url": "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DBiologyFields1hV19-05",
@@ -882,7 +644,7 @@
     },
     "salishseacast_3d_currents": {
         "enabled": true,
-        "name": "27. SalishSeaCast 3D Currents",
+        "name": "24. SalishSeaCast 3D Currents",
         "envtype": ["ocean"],
         "type": "historical",
         "url": [
@@ -908,7 +670,7 @@
     },
     "salishseacast_3d_tracers": {
         "enabled": true,
-        "name": "29. SalishSeaCast 3D Salinity & Temperature",
+        "name": "25. SalishSeaCast 3D Salinity & Temperature",
         "envtype": ["ocean"],
         "type": "historical",
         "url": "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DTracerFields1hV19-05",
@@ -929,7 +691,7 @@
     },
     "salishseacast_2d_ssh": {
         "enabled": true,
-        "name": "30. SalishSeaCast Sea Surface Height",
+        "name": "26. SalishSeaCast Sea Surface Height",
         "envtype": ["ocean"],
         "type": "historical",
         "url": "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSgSurfaceTracerFields1hV19-05",

--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -164,7 +164,6 @@
         "cache": 6,
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "url": "/data/db/riops-fc3dps.sqlite3",
-	"bathymetry_file_url": "/data/grids/ecc/misc/lat_lon/bathy_meter_giops_latlon_0.2deg_reformatted_lonlatupdate.nc",
         "grid_angle_file_url": "/data/grids/ecc/riops/grid_angle_riops_ps5km60n.nc",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
         "lat_var_key": "latitude",
@@ -185,8 +184,7 @@
 	    "oxygensaturation": { "hide": "true", "name": "Oxygen Saturation", "scale": [4, 11], "unit": "ml/l", "equation": "oxygensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
 	    "nitrogensaturation": { "hide": "true", "name": "Nitrogen Saturation", "scale": [8, 20], "unit": "ml/l", "equation": "nitrogensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [1.5, 60], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
-            "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
-	    "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] }
+            "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
         }
     },
     "riops_fc_2dps": {

--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -123,7 +123,8 @@
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "latitude", "longitude"] },
             "deepsoundchannel": { "name": "Sound Channel Axis", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] },
             "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [1.5, 60], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] },
-            "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] }
+            "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] },
+	    "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] }
         }
     },
     "riops_fc_2dll": {
@@ -184,7 +185,8 @@
 	    "oxygensaturation": { "hide": "true", "name": "Oxygen Saturation", "scale": [4, 11], "unit": "ml/l", "equation": "oxygensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
 	    "nitrogensaturation": { "hide": "true", "name": "Nitrogen Saturation", "scale": [8, 20], "unit": "ml/l", "equation": "nitrogensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [1.5, 60], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
-            "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
+            "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
+	    "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] }
         }
     },
     "riops_fc_2dps": {

--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -2,7 +2,7 @@
     "giops_day": {
         "envtype": ["ocean", "ice"],
         "url": "/data/db/giops-fc3dll-10day.sqlite3",
-	"bathymetry_file_url": "/data/grids/ecc/misc/lat_lon/bathy_meter_giops_latlon_0.2deg_reformatted_lonlatupdate.nc",
+	"bathymetry_file_url": "/data/grids/ecc/giops/bathy_meter_giops_latlon_reformatted-ONav.nc",
         "name": "01. GIOPS 10 day Forecast 3D - LatLon",
         "quantum": "day",
         "type": "forecast",
@@ -101,7 +101,7 @@
     "giops_fc_3dll": {
         "envtype": ["ocean", "ice"],
         "url": "/data/db/giops-fc3dll.sqlite3",
-	"bathymetry_file_url": "/data/grids/ecc/misc/lat_lon/bathy_meter_giops_latlon_0.2deg_reformatted_lonlatupdate.nc",
+	"bathymetry_file_url": "/data/grids/ecc/giops/bathy_meter_giops_latlon_reformatted-ONav.nc",
         "name": "04. GIOPS Daily Forecast 3D - LatLon",
         "quantum": "day",
         "type": "forecast",
@@ -163,7 +163,7 @@
         "type": "forecast",
         "cache": 6,
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
-	"bathymetry_file_url": "/data/grids/ecc/misc/polar_stereographic/bathy_meter_giops_ps5km.nc",
+	"bathymetry_file_url": "/data/grids/ecc/riops/bathy_meter_riops_ps5km_reformatted-ONav.nc",
         "url": "/data/db/riops-fc3dps.sqlite3",
         "grid_angle_file_url": "/data/grids/ecc/riops/grid_angle_riops_ps5km60n.nc",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
@@ -186,7 +186,7 @@
 	    "nitrogensaturation": { "hide": "true", "name": "Nitrogen Saturation", "scale": [8, 20], "unit": "ml/l", "equation": "nitrogensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [1.5, 60], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
             "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
-	    "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] }
+	    "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "yc", "xc"] }
         }
     },
     "riops_fc_2dps": {


### PR DESCRIPTION
Removal of GIOPS Polar Stereographic data sets;

       * GIOPS 10 day Forecast 3D - Polar Stereographic
       * GIOPS 10 day Forecast Surface - Polar Stereographic
       * GIOPS 10 day Forecast Surface - Polar Stereographic

Reordered the remaining data sets.

Updated following data sets to use the new *bathymetry_file_url* variable set to "/data/grids/ecc/misc/lat_lon/bathy_meter_giops_latlon_0.2deg_reformatted_lonlatupdate.nc"

       * GIOPS 10 day Forecast 3D - LatLon
       * GIOPS Daily Forecast 3D - LatLon

Added the new variable *depthexcess* to the following data sets;

       * GIOPS Daily Forecast 3D - LatLon
       * RIOPS Forecast 3D - Polar Stereographic

Removed some data sets which had the string "enabled": false defined. 