### PR TITLE
Correct CCG RIOPS Model Class in datasetconfig.json

### DIFF
--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -141,7 +141,7 @@
         "type": "forecast",
         "cache": 6,
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
-        "model_class": "Nemo",
+        "model_class": "Mercator",
         "url": "/data/db/riops-fc2dll.sqlite3",
         "grid_angle_file_url": "/data/grids/riops/grid_angle.nc",
         "attribution": "Environment and Climate Change Canada",


### PR DESCRIPTION
## Background
The model_class attribute was added to datasets in datasetconfig.json in PR#17. This addition allows the Navigator to determine which model to use for a dataset without having to open it's ncfiles. During this update the _05. CCG RIOPS Forecast Surface - LatLon_ model class was set to Nemo however the lat and lon variables are 1D so the Navigator fails to import the data. This issue seems to be resolved by changing the model_class attribute for the dataset.

![CCG_Nemo](https://user-images.githubusercontent.com/79917349/114057125-e0c79c00-986c-11eb-9d96-7329fa2bbae3.png)

![CCG_Mercator](https://user-images.githubusercontent.com/79917349/114057139-e45b2300-986c-11eb-9118-31422aac7a0d.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.