### PR TITLE
Disable SalishSeaCast Datasets

### DIFF
--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -28,7 +28,7 @@
             "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] },
             "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] },
             "psubsurfacechannel":{"name":"Potential Sub Surface Channel","unit":"","scale":[0,1],"equation":"potentialsubsurfacechannel([depth],latitude, [votemper] - 273.15, [vosaline])","dims":["time","latitude","longitude"], "interpolation":{"interpType": "nearest","interpRadius": 25, "interpNeighbours": 10}},
-	     "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "depth", "latitude", "longitude"] }
+	        "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "depth", "latitude", "longitude"] }
         }
     },
     "giops_fc_10d_2dll": {
@@ -641,7 +641,7 @@
         }
     },
     "salishseacast_3d_biology": {
-        "enabled": true,
+        "enabled": false,
         "name": "23. SalishSeaCast 3D Biology",
         "envtype": ["ocean"],
         "type": "historical",
@@ -672,7 +672,7 @@
         }
     },
     "salishseacast_3d_currents": {
-        "enabled": true,
+        "enabled": false,
         "name": "24. SalishSeaCast 3D Currents",
         "envtype": ["ocean"],
         "type": "historical",
@@ -699,7 +699,7 @@
         }
     },
     "salishseacast_3d_tracers": {
-        "enabled": true,
+        "enabled": false,
         "name": "25. SalishSeaCast 3D Salinity & Temperature",
         "envtype": ["ocean"],
         "type": "historical",
@@ -721,7 +721,7 @@
         }
     },
     "salishseacast_2d_ssh": {
-        "enabled": true,
+        "enabled": false,
         "name": "26. SalishSeaCast Sea Surface Height",
         "envtype": ["ocean"],
         "type": "historical",


### PR DESCRIPTION
The SalishSeaCast is currently experiencing issues with their storage systems and ERDDAP servers that prevent us from displaying these datasets. These issues may take some time to resolve so they have recommended that we disable these datasets in the Navigator for now. 