### PR TITLE
Add  "bearing_component" in "magwatervel" variable component for multiple quiver variable options in UI

### DIFF
--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -19,7 +19,7 @@
         "variables": {
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty", "bearing_component":"bearing" },
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "latitude", "longitude"] },
@@ -28,7 +28,7 @@
             "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] },
             "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] },
             "psubsurfacechannel":{"name":"Potential Sub Surface Channel","unit":"","scale":[0,1],"equation":"potentialsubsurfacechannel([depth],latitude, [votemper] - 273.15, [vosaline])","dims":["time","latitude","longitude"], "interpolation":{"interpType": "nearest","interpRadius": 25, "interpNeighbours": 10}},
-	     "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "depth", "latitude", "longitude"] }
+	    "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "depth", "latitude", "longitude"] }
         }
     },
     "giops_fc_10d_2dll": {
@@ -50,7 +50,7 @@
         "variables": {
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" , "bearing_component":"bearing_water"},
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sossheig": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-3, 3], "zero_centered": "true" },
@@ -62,9 +62,11 @@
             "isnowvol": { "name": "Snow Volume", "envtype": "ice", "unit": "cm", "scale": [0, 2000] },
             "itmecrty": { "name": "Sea Ice North Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
             "itzocrtx": { "name": "Sea Ice East Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
-            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty" },
+            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty" , "bearing_component":"bearing_seaice"},
             "iicestrength": { "name": "Compressive Ice Strength", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] },
-            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] }
+            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(itmecrty, itzocrtx)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "giops_fc_2dll": {
@@ -86,7 +88,7 @@
         "variables": {
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty", "bearing_component":"bearing_water"},
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sossheig": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-3, 3], "zero_centered": "true" },
@@ -98,9 +100,11 @@
             "isnowvol": { "name": "Snow Volume", "envtype": "ice", "unit": "cm", "scale": [0, 2000] },
             "itmecrty": { "name": "Sea Ice North Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
             "itzocrtx": { "name": "Sea Ice East Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
-            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty" },
+            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty", "bearing_component":"bearing_seaice" },
             "iicestrength": { "name": "Compressive Ice Strength", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] },
-            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] }
+            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(itmecrty, itzocrtx)" ,"dims": ["time", "latitude", "longitude"] }
          }
     },
     "giops_fc_3dll": {
@@ -123,15 +127,16 @@
         "variables": {
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty", "bearing_component":"bearing" },
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "latitude", "longitude"] },
             "deepsoundchannel": { "name": "Sound Channel Axis", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] },
             "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [1.5, 60], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] },
             "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] },
-	        "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] },
-            "psubsurfacechannel":{"name":"Potential Sub Surface Channel","unit":"","scale":[0,1],"equation":"potentialsubsurfacechannel([depth],latitude, [votemper] - 273.15, [vosaline])","dims":["time","latitude","longitude"]}
+	    "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] },
+            "psubsurfacechannel":{"name":"Potential Sub Surface Channel","unit":"","scale":[0,1],"equation":"potentialsubsurfacechannel([depth],latitude, [votemper] - 273.15, [vosaline])","dims":["time","latitude","longitude"]},
+            "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "depth", "latitude", "longitude"] }
             
         }
     },
@@ -151,15 +156,17 @@
         "attribution": "Environment and Climate Change Canada",
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
+        "vector_arrow_stride": 10,
         "variables": {
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty", "bearing_component":"bearing" },
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sossheig": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-3, 3], "zero_centered": "true" },
             "iiceconc": { "name": "Ice Concentration", "envtype": "ice", "unit": "fraction", "scale": [0, 1] },
-            "iicevol": { "name": "Ice Volume", "envtype": "ice", "unit": "m", "scale": [0, 10] }
+            "iicevol": { "name": "Ice Volume", "envtype": "ice", "unit": "m", "scale": [0, 10] },
+            "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "riops_fc_3dps": {
@@ -173,7 +180,7 @@
         "cache": 6,
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "model_class": "Nemo",
-	    "bathymetry_file_url": "/data/grids/ecc/riops/bathy_meter_riops_ps5km_reformatted-ONav.nc",
+	"bathymetry_file_url": "/data/grids/ecc/riops/bathy_meter_riops_ps5km_reformatted-ONav.nc",
         "url": "/data/db/riops-fc3dps.sqlite3",
         "grid_angle_file_url": "/data/grids/ecc/riops/grid_angle_riops_ps5km60n.nc",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
@@ -254,6 +261,7 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/wcps.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
 
         "variables": {
             "uwindsurf": { "name": "Surface Wind East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-15, 15], "zero_centered": "true" },
@@ -261,7 +269,7 @@
             "magwindsurf": { "name": "Suface Wind Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 15], "equation": "magnitude(uwindsurf, vwindsurf)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "uwindsurf", "north_vector_component": "vwindsurf" },
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty", "bearing_component":"bearing_water" },
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-0.07, 5], "equation": "votemper - 273.15", "dims": ["time", "latitude", "longitude"] },
             "tairsurf": { "name": "Surface Air Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-20, 20], "equation": "tairsurf - 273.15", "dims": ["time", "latitude", "longitude"] },
             "sossheig": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-2, 2], "zero_centered": "true" },
@@ -270,9 +278,11 @@
             "iicevol": { "name": "Sea Ice Volume", "envtype": "ice", "unit": "m", "scale": [0, 10] },
             "itmecrty": { "name": "Sea Ice North Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
             "itzocrtx": { "name": "Sea Ice East Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
-            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty" },
+            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty", "bearing_component":"bearing_seaice" },
             "iicestrength": { "name": "Compressive Ice Strength", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1], "equation" : "iicestrength * 10000", "dims": ["time", "latitude", "longitude"] },
-            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-17, 40], "equation" : "iicepressure * 100", "dims": ["time", "latitude", "longitude"] }
+            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-17, 40], "equation" : "iicepressure * 100", "dims": ["time", "latitude", "longitude"] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(itmecrty, itzocrtx)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "ciops_east3d": {
@@ -434,13 +444,15 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/cmems-global-analysis-forecast-phy-001-024.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" },
-            "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] }
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" , "bearing_component":"bearing"},
+            "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] },
+            "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] }
         }
     },
     "cmems-global-analysis-forecast-phy-001-024_monthly": {
@@ -456,20 +468,23 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/cmems-global-analysis-forecast-phy-001-024.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" , "bearing_component":"bearing_water"},
             "vsi": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-1, 1] },
             "usi": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-1, 1] },
-            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi" },
+            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi", "bearing_component":"bearing_seaice" },
             "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
             "sithick": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 10] },
             "bottomT": { "name": "Sea Floor Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] },
-            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] }
+            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vsi, usi)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "cmems_daily": {
@@ -485,20 +500,23 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/cmems-global_reanalysis_phy_001_030.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "uo": "vo" },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "uo": "vo" , "bearing_component":"bearing_water"},
             "vsi": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-1, 1] },
             "usi": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-1, 1] },
-            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi" },
+            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi", "bearing_component":"bearing_seaice"},
             "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
             "sithick": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 10] },
             "bottomT": { "name": "Sea Floor Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] },
-            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] }
+            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vsi, usi)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "cmems_monthly": {
@@ -514,20 +532,23 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/cmems-GLOBAL_REANALYSIS_PHY_001_030.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo", "bearing_component":"bearing_water" },
             "vsi": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-1, 1] },
             "usi": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-1, 1] },
-            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi" },
+            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi", "bearing_component":"bearing_seaice" },
             "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
             "sithick": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 10] },
             "bottomT": { "name": "Sea Floor Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] },
-            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] }
+            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vsi, usi)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "cmems_monthly_climatology": {
@@ -543,20 +564,23 @@
         "attribution": "E.U. Copernicus Marine Service Information (CMEMS)",
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-2, 26] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [9.5, 38.5] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo", "bearing_component":"bearing_water" },
             "vsi": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-1, 1] },
             "usi": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-1, 1] },
-            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi" },
+            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi", "bearing_component":"bearing_seaice" },
             "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
             "sithick": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 1] },
             "bottomT": { "name": "Sea Floor Temperature", "unit": "Celsius", "scale": [-2, 26] },
             "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-2, 2] },
-            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 430] }
+            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 430] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vsi, usi)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "cmems_seasonal_climatolog": {
@@ -572,20 +596,23 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/glorys12_climatology_seasonal.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-2, 26] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [9.5, 38.5] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo", "bearing_component":"bearing_water" },
             "vsi": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-1, 1] },
             "usi": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-1, 1] },
-            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi" },
+            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi", "bearing_component":"bearing_seaice" },
             "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
             "sithick": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 1] },
             "bottomT": { "name": "Sea Floor Temperature", "unit": "Celsius", "scale": [-2, 26] },
             "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-2, 2] },
-            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 430] }
+            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 430] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vsi, usi)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "freebiorys2v4_daily": {
@@ -739,6 +766,34 @@
         "help": " Document <a href=\"../data-help/salishseacast_2d_ssh.html\" target=\"_new\">link</a>.",
         "variables": {
             "ssh": { "name":  "Sea Surface Height", "unit":  "m", "scale":  [-4, 4], "zero_centered": "true" }
+        }
+    },
+    "gdwps_fc_2d_wave": {
+        "envtype": ["ocean", "ice"],
+        "url": "/home/prodyut.roy/GDWPS_db/GDWPS.sqlite3",
+        "name": "27. Global Deterministic Wave Prediction System (GDWPS) - LatLon",
+        "quantum": "hour",
+        "type": "forecast",
+        "time_dim_units": "seconds since 1970-01-01 00:00:00",
+        "model_class": "Mercator",
+        "enabled": true,
+        "cache": 6,
+        "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
+        "lat_var_key": "latitude",
+        "lon_var_key": "longitude",
+        "help": " Document <a href=\"../data-help/gdwps-10day.html\" target=\"_new\">link</a>.",
+
+        "variables": {
+            "shww": { "name": "Significant height of wind waves", "envtype": "ocean", "unit": "m", "scale": [0, 25], "zero_centered": "false" },
+            "u10": { "name": "10 metre U wind component", "envtype": "ocean", "unit": "m/s", "scale": [-50, 50], "zero_centered": "true" },
+            "v10": { "name": "10 metre V wind component", "envtype": "ocean", "unit": "m/s", "scale": [-50, 50], "zero_centered": "true" },  
+            "wvdir": { "name": "Direction of wind waves", "envtype": "ocean", "unit": "degrees", "scale": [0, 360], "zero_centered": "false" },
+            "mp2": { "name": "Mean zero-crossing wave period", "envtype": "ocean", "unit": "s", "scale": [0, 60], "zero_centered": "false" },
+            "pp1d": { "name": "Peak wave period", "envtype": "ocean", "unit": "s", "scale": [0, 60], "zero_centered": "false" },
+            "siconc": { "name": "Sea ice area fraction", "envtype": "ocean", "unit": "%", "scale": [0, 1], "zero_centered": "false" },
+            "swh": { "name": "Significant height of combined wind waves and swell", "envtype": "ocean", "unit": "m", "scale": [0, 25], "zero_centered": "false" },
+            "magwindvel": { "name": "Wind Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 50], "equation": "magnitude(u10, v10)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "u10", "north_vector_component": "v10", "bearing_component":"bearing" },
+            "bearing": { "hide": "true", "name": "Wind Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(v10, u10)" ,"dims": ["time", "latitude", "longitude"] }
         }
     }
 }

--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -767,33 +767,5 @@
         "variables": {
             "ssh": { "name":  "Sea Surface Height", "unit":  "m", "scale":  [-4, 4], "zero_centered": "true" }
         }
-    },
-    "gdwps_fc_2d_wave": {
-        "envtype": ["ocean", "ice"],
-        "url": "/home/prodyut.roy/GDWPS_db/GDWPS.sqlite3",
-        "name": "27. Global Deterministic Wave Prediction System (GDWPS) - LatLon",
-        "quantum": "hour",
-        "type": "forecast",
-        "time_dim_units": "seconds since 1970-01-01 00:00:00",
-        "model_class": "Mercator",
-        "enabled": true,
-        "cache": 6,
-        "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
-        "lat_var_key": "latitude",
-        "lon_var_key": "longitude",
-        "help": " Document <a href=\"../data-help/gdwps-10day.html\" target=\"_new\">link</a>.",
-
-        "variables": {
-            "shww": { "name": "Significant height of wind waves", "envtype": "ocean", "unit": "m", "scale": [0, 25], "zero_centered": "false" },
-            "u10": { "name": "10 metre U wind component", "envtype": "ocean", "unit": "m/s", "scale": [-50, 50], "zero_centered": "true" },
-            "v10": { "name": "10 metre V wind component", "envtype": "ocean", "unit": "m/s", "scale": [-50, 50], "zero_centered": "true" },  
-            "wvdir": { "name": "Direction of wind waves", "envtype": "ocean", "unit": "degrees", "scale": [0, 360], "zero_centered": "false" },
-            "mp2": { "name": "Mean zero-crossing wave period", "envtype": "ocean", "unit": "s", "scale": [0, 60], "zero_centered": "false" },
-            "pp1d": { "name": "Peak wave period", "envtype": "ocean", "unit": "s", "scale": [0, 60], "zero_centered": "false" },
-            "siconc": { "name": "Sea ice area fraction", "envtype": "ocean", "unit": "%", "scale": [0, 1], "zero_centered": "false" },
-            "swh": { "name": "Significant height of combined wind waves and swell", "envtype": "ocean", "unit": "m", "scale": [0, 25], "zero_centered": "false" },
-            "magwindvel": { "name": "Wind Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 50], "equation": "magnitude(u10, v10)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "u10", "north_vector_component": "v10", "bearing_component":"bearing" },
-            "bearing": { "hide": "true", "name": "Wind Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(v10, u10)" ,"dims": ["time", "latitude", "longitude"] }
-        }
-    }
+    }  
 }


### PR DESCRIPTION
This PR is linked with ## https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/pull/1032.
This PR added a new feature in the quiver selection for the end user. The user now able to plot multiple quiver variables (one at a time) from the quiver selection menu. The current available quiver variables to plot are:

- "Water Velocity" ("magwatervel")
- "Sea Ice Velocity" ("magicevel")
There was only one variable which is "Water Velocity" ("magwatervel") was available to plot in the quiver variable selection option. This PR made the option available to add more quiver variables if required in future for the end user.
#Changes Made in the Config File:
In the datasetconfig.json file, a component name "bearing_component" was added in the "magwatervel" variable.