### PR TITLE
Add "bearing_component" in "magwatervel" variable component for multiple quiver variable options in UI

### DIFF
--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -19,7 +19,7 @@
         "variables": {
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty", "bearing_component":"bearing" },
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "latitude", "longitude"] },
@@ -50,7 +50,7 @@
         "variables": {
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" , "bearing_component":"bearing_water"},
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sossheig": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-3, 3], "zero_centered": "true" },
@@ -62,9 +62,11 @@
             "isnowvol": { "name": "Snow Volume", "envtype": "ice", "unit": "cm", "scale": [0, 2000] },
             "itmecrty": { "name": "Sea Ice North Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
             "itzocrtx": { "name": "Sea Ice East Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
-            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty" },
+            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty" , "bearing_component":"bearing_seaice"},
             "iicestrength": { "name": "Compressive Ice Strength", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] },
-            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] }
+            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(itmecrty, itzocrtx)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "giops_fc_2dll": {
@@ -86,7 +88,7 @@
         "variables": {
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty", "bearing_component":"bearing_water"},
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sossheig": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-3, 3], "zero_centered": "true" },
@@ -98,9 +100,11 @@
             "isnowvol": { "name": "Snow Volume", "envtype": "ice", "unit": "cm", "scale": [0, 2000] },
             "itmecrty": { "name": "Sea Ice North Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
             "itzocrtx": { "name": "Sea Ice East Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
-            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty" },
+            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty", "bearing_component":"bearing_seaice" },
             "iicestrength": { "name": "Compressive Ice Strength", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] },
-            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] }
+            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(itmecrty, itzocrtx)" ,"dims": ["time", "latitude", "longitude"] }
          }
     },
     "giops_fc_3dll": {
@@ -123,7 +127,7 @@
         "variables": {
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty", "bearing_component":"bearing" },
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "latitude", "longitude"] },
@@ -133,6 +137,7 @@
 	        "depthexcess": { "name": "Depth Excess", "unit": "m", "scale": [0, 1000], "equation": "depthexcess([depth], latitude, [votemper] - 273.15, [vosaline], bathy)", "dims": ["time", "latitude", "longitude"] },
             "psubsurfacechannel":{"name":"Potential Sub Surface Channel","unit":"","scale":[0,1],"equation":"potentialsubsurfacechannel([depth],latitude, [votemper] - 273.15, [vosaline])","dims":["time","latitude","longitude"]},
             "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "depth", "latitude", "longitude"] }
+            
         }
     },
     "riops_fc_2dll": {
@@ -151,16 +156,17 @@
         "attribution": "Environment and Climate Change Canada",
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
+        "vector_arrow_stride": 10,
         "variables": {
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty", "bearing_component":"bearing" },
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sossheig": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-3, 3], "zero_centered": "true" },
             "iiceconc": { "name": "Ice Concentration", "envtype": "ice", "unit": "fraction", "scale": [0, 1] },
             "iicevol": { "name": "Ice Volume", "envtype": "ice", "unit": "m", "scale": [0, 10] },
-	    "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "latitude", "longitude"] }
+            "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "riops_fc_3dps": {
@@ -174,7 +180,7 @@
         "cache": 6,
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "model_class": "Nemo",
-	    "bathymetry_file_url": "/data/grids/ecc/riops/bathy_meter_riops_ps5km_reformatted-ONav.nc",
+	"bathymetry_file_url": "/data/grids/ecc/riops/bathy_meter_riops_ps5km_reformatted-ONav.nc",
         "url": "/data/db/riops-fc3dps.sqlite3",
         "grid_angle_file_url": "/data/grids/ecc/riops/grid_angle_riops_ps5km60n.nc",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
@@ -191,10 +197,10 @@
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "density": { "hide": "true", "name": "Water Density", "envtype": "ocean", "scale": [1000, 1050], "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "heatcapacity": { "hide": "true", "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-	        "tempgradient": { "hide": "true", "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+	    "tempgradient": { "hide": "true", "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "deepsoundchannel": { "name": "Sound Channel Axis", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
-	        "oxygensaturation": { "hide": "true", "name": "Oxygen Saturation", "scale": [4, 11], "unit": "ml/l", "equation": "oxygensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-	        "nitrogensaturation": { "hide": "true", "name": "Nitrogen Saturation", "scale": [8, 20], "unit": "ml/l", "equation": "nitrogensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+	    "oxygensaturation": { "hide": "true", "name": "Oxygen Saturation", "scale": [4, 11], "unit": "ml/l", "equation": "oxygensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+	    "nitrogensaturation": { "hide": "true", "name": "Nitrogen Saturation", "scale": [8, 20], "unit": "ml/l", "equation": "nitrogensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [1.5, 60], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
             "deepsoundchannelbottom": { "name": "Critical Depth", "unit": "m", "scale": [500, 2000], "equation": "deepsoundchannelbottom([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },     
             "psubsurfacechannel":{"name":"Potential Sub Surface Channel","unit":"","scale":[0,1],"equation":"potentialsubsurfacechannel([depth],latitude, [votemper] - 273.15, [vosaline])","dims":["time","yc","xc"]}
@@ -255,6 +261,7 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/wcps.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
 
         "variables": {
             "uwindsurf": { "name": "Surface Wind East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-15, 15], "zero_centered": "true" },
@@ -262,7 +269,7 @@
             "magwindsurf": { "name": "Suface Wind Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 15], "equation": "magnitude(uwindsurf, vwindsurf)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "uwindsurf", "north_vector_component": "vwindsurf" },
             "vozocrtx": { "name": "Water East Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water North Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty", "bearing_component":"bearing_water" },
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-0.07, 5], "equation": "votemper - 273.15", "dims": ["time", "latitude", "longitude"] },
             "tairsurf": { "name": "Surface Air Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-20, 20], "equation": "tairsurf - 273.15", "dims": ["time", "latitude", "longitude"] },
             "sossheig": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-2, 2], "zero_centered": "true" },
@@ -271,9 +278,11 @@
             "iicevol": { "name": "Sea Ice Volume", "envtype": "ice", "unit": "m", "scale": [0, 10] },
             "itmecrty": { "name": "Sea Ice North Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
             "itzocrtx": { "name": "Sea Ice East Velocity", "envtype": "ice", "unit": "m/s", "scale": [-1, 1], "zero_centered": "true" },
-            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty" },
+            "magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty", "bearing_component":"bearing_seaice" },
             "iicestrength": { "name": "Compressive Ice Strength", "envtype": "ice", "unit": "Nm-1", "scale": [-1, 1], "equation" : "iicestrength * 10000", "dims": ["time", "latitude", "longitude"] },
-            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-17, 40], "equation" : "iicepressure * 100", "dims": ["time", "latitude", "longitude"] }
+            "iicepressure": { "name": "Internal Ice Pressure", "envtype": "ice", "unit": "Nm-1", "scale": [-17, 40], "equation" : "iicepressure * 100", "dims": ["time", "latitude", "longitude"] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(itmecrty, itzocrtx)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "ciops_east3d": {
@@ -435,13 +444,15 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/cmems-global-analysis-forecast-phy-001-024.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" },
-            "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] }
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" , "bearing_component":"bearing"},
+            "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] },
+            "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] }
         }
     },
     "cmems-global-analysis-forecast-phy-001-024_monthly": {
@@ -457,20 +468,23 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/cmems-global-analysis-forecast-phy-001-024.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" , "bearing_component":"bearing_water"},
             "vsi": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-1, 1] },
             "usi": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-1, 1] },
-            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi" },
+            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi", "bearing_component":"bearing_seaice" },
             "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
             "sithick": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 10] },
             "bottomT": { "name": "Sea Floor Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] },
-            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] }
+            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vsi, usi)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "cmems_daily": {
@@ -486,20 +500,23 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/cmems-global_reanalysis_phy_001_030.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "uo": "vo" },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "uo": "vo" , "bearing_component":"bearing_water"},
             "vsi": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-1, 1] },
             "usi": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-1, 1] },
-            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi" },
+            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi", "bearing_component":"bearing_seaice"},
             "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
             "sithick": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 10] },
             "bottomT": { "name": "Sea Floor Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] },
-            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] }
+            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vsi, usi)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "cmems_monthly": {
@@ -515,20 +532,23 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/cmems-GLOBAL_REANALYSIS_PHY_001_030.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo", "bearing_component":"bearing_water" },
             "vsi": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-1, 1] },
             "usi": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-1, 1] },
-            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi" },
+            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi", "bearing_component":"bearing_seaice" },
             "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
             "sithick": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 10] },
             "bottomT": { "name": "Sea Floor Temperature", "unit": "Celsius", "scale": [-5, 30] },
             "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3] },
-            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] }
+            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 4000] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vsi, usi)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "cmems_monthly_climatology": {
@@ -544,20 +564,23 @@
         "attribution": "E.U. Copernicus Marine Service Information (CMEMS)",
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-2, 26] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [9.5, 38.5] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo", "bearing_component":"bearing_water" },
             "vsi": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-1, 1] },
             "usi": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-1, 1] },
-            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi" },
+            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi", "bearing_component":"bearing_seaice" },
             "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
             "sithick": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 1] },
             "bottomT": { "name": "Sea Floor Temperature", "unit": "Celsius", "scale": [-2, 26] },
             "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-2, 2] },
-            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 430] }
+            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 430] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vsi, usi)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "cmems_seasonal_climatolog": {
@@ -573,20 +596,23 @@
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "help": " Document <a href=\"../data-help/glorys12_climatology_seasonal.html\" target=\"_new\">link</a>.",
+        "vector_arrow_stride": 10,
         "variables": {
             "thetao": { "name": "Temperature", "unit": "Celsius", "scale": [-2, 26] },
             "so": { "name": "Salinity", "unit": "PSU", "scale": [9.5, 38.5] },
             "vo": { "name": "Water North Velocity", "unit": "m/s", "scale": [-3, 3] },
             "uo": { "name": "Water East Velocity", "unit": "m/s", "scale": [-3, 3] },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo" },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(uo, vo)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "uo", "north_vector_component": "vo", "bearing_component":"bearing_water" },
             "vsi": { "name": "Sea Ice North Velocity", "unit": "m/s", "scale": [-1, 1] },
             "usi": { "name": "Sea Ice East Velocity", "unit": "m/s", "scale": [-1, 1] },
-            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi" },
+            "magicevel": { "name": "Sea Ice Velocity", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(usi, vsi)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "usi", "north_vector_component": "vsi", "bearing_component":"bearing_seaice" },
             "siconc": { "name": "Sea Ice Concentration", "unit": "fraction", "scale": [0, 1] },
             "sithick": { "name": "Sea Ice Thickness", "unit": "m", "scale": [0, 1] },
             "bottomT": { "name": "Sea Floor Temperature", "unit": "Celsius", "scale": [-2, 26] },
             "zos": { "name": "Sea Surface Height", "unit": "m", "scale": [-2, 2] },
-            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 430] }
+            "mlotst": { "name": "Ocean Mixed Layer Thickness", "unit": "m", "scale": [0, 430] },
+            "bearing_water": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vo, uo)" ,"dims": ["time", "depth", "latitude", "longitude"] },
+            "bearing_seaice": { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vsi, usi)" ,"dims": ["time", "latitude", "longitude"] }
         }
     },
     "freebiorys2v4_daily": {


### PR DESCRIPTION
This PR is linked with ## https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/pull/1032.
This PR added a new feature in the quiver selection for the end user. The user now able to plot multiple quiver variables (one at a time) from the quiver selection menu. The current available quiver variables to plot are:

"Water Velocity" ("magwatervel")
"Sea Ice Velocity" ("magicevel")
There was only one variable which is "Water Velocity" ("magwatervel") was available to plot in the quiver variable selection option. This PR made the option available to add more quiver variables if required in future for the end user.
#Changes Made in the Config File:
In the datasetconfig.json file, a component name "bearing_component" was added in the "magwatervel" variable.
See below the change I made for "giops_fc_10d_2dll" dataset as an example:

"giops_fc_10d_2dll": {
 "variables": { 
"magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" , **"bearing_component":"bearing_water"**},

"magicevel": { "name": "Sea Ice Velocity", "envtype": "ice", "unit": "m/s", "scale": [0, 1], "equation": "magnitude(itmecrty, itzocrtx)", "dims": ["time", "latitude", "longitude"], "east_vector_component": "itzocrtx", "north_vector_component": "itmecrty" , **"bearing_component":"bearing_seaice"**},
          
**"bearing_water"**: { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "latitude", "longitude"] },
**"bearing_seaice"**: { "hide": "true", "name": "Sea Ice Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(itmecrty, itzocrtx)" ,"dims": ["time", "latitude", "longitude"] }
