### PR TITLE
Re-enable SSC datasets

### DIFF
--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -1016,7 +1016,7 @@
     "salishseacast_3d_biology": {
         "group": "SalishSeaCast", 
         "subgroup": "3D",  
-        "enabled": false,
+        "enabled": true,
         "name": "SalishSeaCast 3D Biology",
         "envtype": ["ocean"],
         "type": "historical",
@@ -1049,7 +1049,7 @@
     "salishseacast_3d_currents": {
         "group": "SalishSeaCast",
         "subgroup": "3D",
-        "enabled": false,
+        "enabled": true,
         "name": "SalishSeaCast 3D Currents",
         "envtype": ["ocean"],
         "type": "historical",
@@ -1078,7 +1078,7 @@
     "salishseacast_3d_tracers": {
         "group": "SalishSeaCast",
         "subgroup": "3D",
-        "enabled": false,
+        "enabled": true,
         "name": "SalishSeaCast 3D Salinity & Temperature",
         "envtype": ["ocean"],
         "type": "historical",
@@ -1102,7 +1102,7 @@
     "salishseacast_2d_ssh": {
         "group": "SalishSeaCast",
         "subgroup": "2D",
-        "enabled": false,
+        "enabled": true,
         "name": "SalishSeaCast Sea Surface Height",
         "envtype": ["ocean"],
         "type": "historical",

--- a/datasetconfig.json
+++ b/datasetconfig.json
@@ -1070,9 +1070,9 @@
         "attribution": "Mesoscale Ocean & Atmosphere Dynamics Group (MOAD), Earth, Ocean & Atmopspheric Sciences (EOAS), University of British Columbia",
         "help": "<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Document <a href=\"../data-help/salishseacast_3d_currents.html\" target=\"_new\">link</a>.",
         "variables": {
-            "uVelocity": { "name":  "Eastward Current", "units":  "m/s", "scale":  [-8, 8], "zero_centered": "true" },
-            "vVelocity": { "name":  "Northward Current", "units":  "m/s", "scale":  [-8, 8], "zero_centered": "true" },
-            "current_speed": { "name":  "Speed of Current", "units": "m/s", "scale":  [0, 8], "equation": "unstaggered_speed(uVelocity, vVelocity)", "dims": ["time", "depth", "gridY", "gridX"] }
+            "uVelocity": { "name":  "Eastward Current", "units":  "m/s", "scale":  [-3, 3], "zero_centered": "true" },
+            "vVelocity": { "name":  "Northward Current", "units":  "m/s", "scale":  [-3, 3], "zero_centered": "true" },
+            "current_speed": { "name":  "Speed of Current", "units": "m/s", "scale":  [0, 3], "equation": "unstaggered_speed(uVelocity, vVelocity)", "dims": ["time", "depth", "gridY", "gridX"] }
         }
     },
     "salishseacast_3d_tracers": {


### PR DESCRIPTION
Following the work of [#1087](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/pull/1087) we can now re-enable the affected datasets. Note that the variable scales of the u, v, and combined water velocity variables has been limited to [-3, 3].